### PR TITLE
feat(framework): increase version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## 0.0.2 (2024-10-09)
 
-
 ### Features
 
-* init open source package ([73561a9](https://github.com/i-am-bee/bee-observe-connector/commit/73561a9ed3c827a752602ff01f57ae5a0eb8b74f))
+- init open source package ([73561a9](https://github.com/i-am-bee/bee-observe-connector/commit/73561a9ed3c827a752602ff01f57ae5a0eb8b74f))

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "coverage": "vitest run --coverage",
     "ts:check": "tsc --noEmit",
     "start:infra": "docker compose -f ./infra/compose.yml up -d",
+    "stop:infra": "docker compose -f ./infra/compose.yml down",
     "generate:schema": "bash ./scripts/generate-schema.sh"
   },
   "devDependencies": {
@@ -34,7 +35,7 @@
     "@types/eslint": "^9",
     "@types/node": "^22.5.0",
     "@vitest/coverage-v8": "^2.0.5",
-    "bee-agent-framework": "^0.0.26",
+    "bee-agent-framework": "^0.0.27",
     "eslint": "^9.9.1",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-import": "^2.29.1",
@@ -57,7 +58,7 @@
     "openapi-fetch": "^0.11.1"
   },
   "peerDependencies": {
-    "bee-agent-framework": "^0.0.26"
+    "bee-agent-framework": ">=0.0.27 <0.1.0"
   },
   "files": [
     "dist/**/*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2095,9 +2095,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bee-agent-framework@npm:^0.0.26":
-  version: 0.0.26
-  resolution: "bee-agent-framework@npm:0.0.26"
+"bee-agent-framework@npm:^0.0.27":
+  version: 0.0.27
+  resolution: "bee-agent-framework@npm:0.0.27"
   dependencies:
     "@ai-zen/node-fetch-event-source": "npm:^2.1.4"
     "@connectrpc/connect": "npm:^1.4.0"
@@ -2142,7 +2142,7 @@ __metadata:
     openai: ^4.56.0
     openai-chat-tokens: ^0.2.8
     sequelize: ^6.37.3
-  checksum: 10c0/52f7e0c9b20275f1dc8ca9cdade5588a926c84224222581de6c9d6f0ed06e7523cf321495af38945142078d68c29dc9e881749ec08ae968f1747dd67569c2578
+  checksum: 10c0/663767849df3666805b1fe0b0042afaecc971bbd5a19c94bf6fdffff3a62873b95625849e67483d417b2f1a0ebcb54513066bc36c29260b400c4a9d5929a02ef
   languageName: node
   linkType: hard
 
@@ -2159,7 +2159,7 @@ __metadata:
     "@types/eslint": "npm:^9"
     "@types/node": "npm:^22.5.0"
     "@vitest/coverage-v8": "npm:^2.0.5"
-    bee-agent-framework: "npm:^0.0.26"
+    bee-agent-framework: "npm:^0.0.27"
     eslint: "npm:^9.9.1"
     eslint-config-prettier: "npm:^9.1.0"
     eslint-plugin-import: "npm:^2.29.1"
@@ -2179,7 +2179,7 @@ __metadata:
     vite-tsconfig-paths: "npm:^5.0.1"
     vitest: "npm:^2.0.5"
   peerDependencies:
-    bee-agent-framework: ^0.0.26
+    bee-agent-framework: ">=0.0.27 <0.1.0"
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
I set the 
```
"peerDependencies": {
    "bee-agent-framework": ">=0.0.27 <0.1.0"
  },
```
to prevent errors in the framework where the framework dependency is linked to the repo and the current version is used. 
It prevents the error in package versions like:
```
bee-agent-framework is listed by your project with version 0.0.27, which doesn't satisfy what bee-observe-connector (p1edff) requests (>=0.0.26 <0.0.27-0).
```